### PR TITLE
Use StringSource for docker_image

### DIFF
--- a/dagster-nomad/dagster_nomad/run_launcher.py
+++ b/dagster-nomad/dagster_nomad/run_launcher.py
@@ -131,7 +131,7 @@ class NomadRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
     def config_type(cls) -> dict[str, Field]:
         return {
             "docker_image": Field(
-                str,
+                StringSource,
                 is_required=False,
                 description="The docker image to be used if the repository does not specify one.",
             ),


### PR DESCRIPTION
This gives users the option to pass the `docker_image` from an environment variable, mirroring how the rest of the configuration such as `job_id` can be passed.

I've had success with this in my own infrastructure, specifying either a string or a dict specifying an env var.

Example `dagster.yaml`:

```yaml
run_launcher:
  module: dagster_nomad
  class: NomadRunLauncher
  config:
    job_id:
      env: DAGSTER_NOMAD_JOB_ID
    url:
      env: DAGSTER_NOMAD_URL
    docker_image:
      env: DAGSTER_EXECUTOR_DOCKER_IMAGE
```