### PR TITLE
Improve logging, prepare new release. Add Lucas to maintenairs

### DIFF
--- a/dagster-nomad/dagster_nomad/run_launcher.py
+++ b/dagster-nomad/dagster_nomad/run_launcher.py
@@ -65,7 +65,7 @@ class NomadClient(httpx2.Client):
         res.raise_for_status()
         return res.json()["DispatchedJobID"]
 
-    def get_job_status(self, job_id: str) -> tuple[str, bool]:
+    def get_job_status(self, job_id: str) -> tuple[str, str, bool]:
         """Retrieve the status of the provided job id.
 
         Args:
@@ -85,7 +85,9 @@ class NomadClient(httpx2.Client):
         state: str = data[0]["TaskStates"][task]["State"]
         failed: bool = data[0]["TaskStates"][task]["Failed"]
 
-        return state, failed
+        alloc_id = data[0]["ID"]
+
+        return alloc_id, state, failed
 
     def stop_job(self, job_id: str) -> None:
         """Stop a job
@@ -250,7 +252,7 @@ class NomadRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
         dispatched_job_id = run.tags.get(self.NOMAD_DISPATCHED_JOB_ID_TAG)
 
         try:
-            state, failed = self.nomad_client.get_job_status(dispatched_job_id)
+            alloc_id, state, failed = self.nomad_client.get_job_status(dispatched_job_id)
         except httpx2.HTTPError as exc:
             self._instance.report_engine_event(
                 message=f"Failed to get run status of dispatched_job_id `{dispatched_job_id}`: `{exc}",
@@ -261,6 +263,11 @@ class NomadRunLauncher(RunLauncher[T_DagsterInstance], ConfigurableClass):
 
         match (state, failed):
             case ("running", _):
+                self._instance.report_engine_event(
+                    message=f"Job is running: `com.hashicorp.nomad.alloc_id: {alloc_id}`",
+                    dagster_run=run,
+                    cls=self.__class__,
+                )
                 return CheckRunHealthResult(WorkerStatus.RUNNING)
             case ("dead", True):
                 return CheckRunHealthResult(WorkerStatus.FAILED)

--- a/dagster-nomad/dagster_nomad_test/test_nomad_client.py
+++ b/dagster-nomad/dagster_nomad_test/test_nomad_client.py
@@ -170,7 +170,8 @@ class TestNomadClientGetJobStatus:
 
         client = NomadClient(url="http://nomad.example.com", transport=httpx2.MockTransport(handler))
 
-        state, failed = client.get_job_status("test_job")
+        alloc_id, state, failed = client.get_job_status("test_job")
 
+        assert alloc_id == "c7fda1f4-e05d-e113-cb7e-0f7956fab617"
         assert state == "dead"
         assert failed is False

--- a/dagster-nomad/pyproject.toml
+++ b/dagster-nomad/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "dagster-nomad"
-version = "0.1.1"
+version = "0.1.2"
 description = "Dagster integration library for Nomad"
 readme = "README.md"
 authors = [
     { name = "Bruno Bonfils", email = "asyd@asyd.net" },
     { name = "Thomas Aubry", email = "github.thomaub@gmail.com" },
     { name = "Thomas Berdy", email = "thomas.berdy@outlook.com" },
+    { name = "Lucas Pauzies", email = "lucas.pauzies@hotmail.fr" },
 ]
 keywords = ["dagster", "nomad", "run launcher"]
 classifiers = [

--- a/dagster/dagster.yaml
+++ b/dagster/dagster.yaml
@@ -22,5 +22,10 @@ compute_logs:
     endpoint_url:
       env: DAGSTER_S3_ENDPOINT_URL
 
+run_monitoring:
+  enabled: true
+  start_timeout_seconds: 300
+  poll_interval_seconds: 5
+
 telemetry:
   enabled: false

--- a/uv.lock
+++ b/uv.lock
@@ -257,7 +257,7 @@ wheels = [
 
 [[package]]
 name = "dagster-nomad"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "dagster-nomad" }
 dependencies = [
     { name = "dagster" },


### PR DESCRIPTION
Since it's not possible to known the allocation id after dispatch, we use the `check_run_worker_health` to display Nomad allocation id. To ensure this function is called, ensure you have following section in `dagster.yml`:

```
run_monitoring:
  enabled: true
  # start_timeout_seconds: 300 (default value is 180)
  # poll_interval_seconds: 5 (default value is 120)
```
